### PR TITLE
fix: withdraw non frozen protocol fee

### DIFF
--- a/programs/cp-amm/src/instructions/admin/ix_claim_protocol_fee.rs
+++ b/programs/cp-amm/src/instructions/admin/ix_claim_protocol_fee.rs
@@ -69,27 +69,34 @@ pub struct ClaimProtocolFeesCtx<'info> {
 pub fn handle_claim_protocol_fee(ctx: Context<ClaimProtocolFeesCtx>) -> Result<()> {
     let mut pool = ctx.accounts.pool.load_mut()?;
 
-    let (token_a_amount, token_b_amount) = pool.claim_protocol_fee();
+    let (token_a_amount, token_b_amount) = pool.claim_protocol_fee(
+        ctx.accounts.token_a_vault.is_frozen(),
+        ctx.accounts.token_b_vault.is_frozen(),
+    );
 
-    transfer_from_pool(
-        ctx.accounts.pool_authority.to_account_info(),
-        &ctx.accounts.token_a_mint,
-        &ctx.accounts.token_a_vault,
-        &ctx.accounts.token_a_account,
-        &ctx.accounts.token_a_program,
-        token_a_amount,
-        ctx.bumps.pool_authority,
-    )?;
+    if token_a_amount > 0 {
+        transfer_from_pool(
+            ctx.accounts.pool_authority.to_account_info(),
+            &ctx.accounts.token_a_mint,
+            &ctx.accounts.token_a_vault,
+            &ctx.accounts.token_a_account,
+            &ctx.accounts.token_a_program,
+            token_a_amount,
+            ctx.bumps.pool_authority,
+        )?;
+    }
 
-    transfer_from_pool(
-        ctx.accounts.pool_authority.to_account_info(),
-        &ctx.accounts.token_b_mint,
-        &ctx.accounts.token_b_vault,
-        &ctx.accounts.token_b_account,
-        &ctx.accounts.token_b_program,
-        token_b_amount,
-        ctx.bumps.pool_authority,
-    )?;
+    if token_b_amount > 0 {
+        transfer_from_pool(
+            ctx.accounts.pool_authority.to_account_info(),
+            &ctx.accounts.token_b_mint,
+            &ctx.accounts.token_b_vault,
+            &ctx.accounts.token_b_account,
+            &ctx.accounts.token_b_program,
+            token_b_amount,
+            ctx.bumps.pool_authority,
+        )?;
+    }
 
     emit_cpi!(EvtClaimProtocolFee {
         pool: ctx.accounts.pool.key(),

--- a/programs/cp-amm/src/state/pool.rs
+++ b/programs/cp-amm/src/state/pool.rs
@@ -682,11 +682,27 @@ impl Pool {
         Ok(())
     }
 
-    pub fn claim_protocol_fee(&mut self) -> (u64, u64) {
-        let token_a_amount = self.protocol_a_fee;
-        let token_b_amount = self.protocol_b_fee;
-        self.protocol_a_fee = 0;
-        self.protocol_b_fee = 0;
+    pub fn claim_protocol_fee(
+        &mut self,
+        is_token_a_frozen: bool,
+        is_token_b_frozen: bool,
+    ) -> (u64, u64) {
+        let token_a_amount = if !is_token_a_frozen {
+            let token_a_amount = self.protocol_a_fee;
+            self.protocol_a_fee = 0;
+            token_a_amount
+        } else {
+            0
+        };
+
+        let token_b_amount = if !is_token_b_frozen {
+            let token_b_amount = self.protocol_b_fee;
+            self.protocol_b_fee = 0;
+            token_b_amount
+        } else {
+            0
+        };
+
         (token_a_amount, token_b_amount)
     }
 


### PR DESCRIPTION
## Context

Token creator freeze the reserve account and causes withdrawal of protocol fees to fail.

## Solution

Skip transfer of protocol fee from the reserve account that is frozen. This allows us to claim the protocol fee only on non-frozen reserve account.