### PR TITLE
Make SwapParameters fields public

### DIFF
--- a/programs/cp-amm/src/instructions/ix_swap.rs
+++ b/programs/cp-amm/src/instructions/ix_swap.rs
@@ -13,8 +13,8 @@ use crate::{
 
 #[derive(AnchorSerialize, AnchorDeserialize)]
 pub struct SwapParameters {
-    amount_in: u64,
-    minimum_amount_out: u64,
+    pub amount_in: u64,
+    pub minimum_amount_out: u64,
 }
 
 #[event_cpi]


### PR DESCRIPTION
Fields of swap params struct are private.

So, if you are trying to CPI from your anchor program, using anchor cpi feature, you won't be able to do so, since there is no way for you to construct SwapParameters:

```rust
// Won't build, since fields are private
cp_amm::cpi::swap(ctx, cp_amm::SwapParameters { amount_in: 0, minimum_amount_out: 0 })?;
```