### PR TITLE
Clean lifetimes

### DIFF
--- a/programs/cp-amm/src/instructions/admin/ix_initialize_reward.rs
+++ b/programs/cp-amm/src/instructions/admin/ix_initialize_reward.rs
@@ -10,6 +10,7 @@ use crate::{
     event::EvtInitializeReward,
     state::Pool,
     token::{get_token_program_flags, is_supported_mint, is_token_badge_initialized},
+    CorrectContext,
 };
 
 #[event_cpi]
@@ -65,8 +66,8 @@ impl<'info> InitializeRewardCtx<'info> {
     }
 }
 
-pub fn handle_initialize_reward<'c: 'info, 'info>(
-    ctx: Context<'_, '_, 'c, 'info, InitializeRewardCtx<'info>>,
+pub fn handle_initialize_reward(
+    ctx: CorrectContext<InitializeRewardCtx>,
     reward_index: u8,
     reward_duration: u64,
     funder: Pubkey,

--- a/programs/cp-amm/src/instructions/initialize_pool/ix_initialize_customizable_pool.rs
+++ b/programs/cp-amm/src/instructions/initialize_pool/ix_initialize_customizable_pool.rs
@@ -23,7 +23,7 @@ use crate::{
         calculate_transfer_fee_included_amount, get_token_program_flags, is_supported_mint,
         is_token_badge_initialized, transfer_from_user,
     },
-    EvtCreatePosition, EvtInitializePool, PoolError,
+    CorrectContext, EvtCreatePosition, EvtInitializePool, PoolError,
 };
 
 use super::{max_key, min_key};
@@ -220,8 +220,8 @@ pub struct InitializeCustomizablePoolCtx<'info> {
     pub system_program: Program<'info, System>,
 }
 
-pub fn handle_initialize_customizable_pool<'c: 'info, 'info>(
-    ctx: Context<'_, '_, 'c, 'info, InitializeCustomizablePoolCtx<'info>>,
+pub fn handle_initialize_customizable_pool(
+    ctx: CorrectContext<InitializeCustomizablePoolCtx>,
     params: InitializeCustomizablePoolParameters,
 ) -> Result<()> {
     params.validate()?;

--- a/programs/cp-amm/src/instructions/initialize_pool/ix_initialize_pool.rs
+++ b/programs/cp-amm/src/instructions/initialize_pool/ix_initialize_pool.rs
@@ -22,7 +22,7 @@ use crate::{
         calculate_transfer_fee_included_amount, get_token_program_flags, is_supported_mint,
         is_token_badge_initialized, transfer_from_user,
     },
-    EvtCreatePosition, EvtInitializePool, PoolError,
+    CorrectContext, EvtCreatePosition, EvtInitializePool, PoolError,
 };
 
 // To fix IDL generation: https://github.com/coral-xyz/anchor/issues/3209
@@ -182,8 +182,8 @@ pub struct InitializePoolCtx<'info> {
     pub system_program: Program<'info, System>,
 }
 
-pub fn handle_initialize_pool<'c: 'info, 'info>(
-    ctx: Context<'_, '_, 'c, 'info, InitializePoolCtx<'info>>,
+pub fn handle_initialize_pool(
+    ctx: CorrectContext<InitializePoolCtx>,
     params: InitializePoolParameters,
 ) -> Result<()> {
     if !is_supported_mint(&ctx.accounts.token_a_mint)? {

--- a/programs/cp-amm/src/instructions/initialize_pool/ix_initialize_pool_with_dynamic_config.rs
+++ b/programs/cp-amm/src/instructions/initialize_pool/ix_initialize_pool_with_dynamic_config.rs
@@ -18,7 +18,7 @@ use crate::{
         calculate_transfer_fee_included_amount, get_token_program_flags, is_supported_mint,
         is_token_badge_initialized, transfer_from_user,
     },
-    validate_quote_token, EvtCreatePosition, EvtInitializePool, PoolError,
+    validate_quote_token, CorrectContext, EvtCreatePosition, EvtInitializePool, PoolError,
 };
 
 use super::{max_key, min_key, InitializeCustomizablePoolParameters};
@@ -164,8 +164,8 @@ pub struct InitializePoolWithDynamicConfigCtx<'info> {
     pub system_program: Program<'info, System>,
 }
 
-pub fn handle_initialize_pool_with_dynamic_config<'c: 'info, 'info>(
-    ctx: Context<'_, '_, 'c, 'info, InitializePoolWithDynamicConfigCtx<'info>>,
+pub fn handle_initialize_pool_with_dynamic_config(
+    ctx: CorrectContext<InitializePoolWithDynamicConfigCtx>,
     params: InitializeCustomizablePoolParameters,
 ) -> Result<()> {
     params.validate()?;

--- a/programs/cp-amm/src/instructions/ix_refresh_vesting.rs
+++ b/programs/cp-amm/src/instructions/ix_refresh_vesting.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeSet;
 use crate::{
     activation_handler::ActivationHandler,
     state::{Pool, Position, Vesting},
-    PoolError,
+    CorrectContext, PoolError,
 };
 
 #[derive(Accounts)]
@@ -48,8 +48,8 @@ impl<'info> VestingRemainingAccount<'info> {
     }
 }
 
-pub fn handle_refresh_vesting<'a, 'b, 'c: 'info, 'info>(
-    ctx: Context<'a, 'b, 'c, 'info, RefreshVesting<'info>>,
+pub fn handle_refresh_vesting<'info>(
+    ctx: CorrectContext<'_, '_, 'info, RefreshVesting<'info>>,
 ) -> Result<()> {
     let pool = ctx.accounts.pool.load()?;
 

--- a/programs/cp-amm/src/instructions/swap/ix_swap.rs
+++ b/programs/cp-amm/src/instructions/swap/ix_swap.rs
@@ -9,7 +9,7 @@ use crate::{
     state::{fee::FeeMode, Pool, SwapResult2},
     swap::{ProcessSwapParams, ProcessSwapResult},
     token::{transfer_from_pool, transfer_from_user},
-    EvtSwap, EvtSwap2, PoolError,
+    CorrectContext, EvtSwap, EvtSwap2, PoolError,
 };
 use anchor_lang::solana_program::sysvar;
 use anchor_lang::{
@@ -107,7 +107,7 @@ impl<'info> SwapCtx<'info> {
     }
 }
 
-pub fn handle_swap_wrapper(ctx: &Context<SwapCtx>, params: SwapParameters2) -> Result<()> {
+pub fn handle_swap_wrapper(ctx: &CorrectContext<SwapCtx>, params: SwapParameters2) -> Result<()> {
     let SwapParameters2 {
         amount_0,
         amount_1,
@@ -282,9 +282,9 @@ pub fn handle_swap_wrapper(ctx: &Context<SwapCtx>, params: SwapParameters2) -> R
     Ok(())
 }
 
-pub fn validate_single_swap_instruction<'c, 'info>(
+pub fn validate_single_swap_instruction<'info>(
     pool: &Pubkey,
-    remaining_accounts: &'c [AccountInfo<'info>],
+    remaining_accounts: &'info [AccountInfo<'info>],
 ) -> Result<()> {
     let instruction_sysvar_account_info = remaining_accounts
         .get(0)

--- a/programs/cp-amm/src/lib.rs
+++ b/programs/cp-amm/src/lib.rs
@@ -29,6 +29,8 @@ pub mod params;
 
 declare_id!("cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG");
 
+pub type CorrectContext<'a, 'b, 'info, T> = Context<'a, 'b, 'info, 'info, T>;
+
 #[program]
 pub mod cp_amm {
     use super::*;
@@ -69,8 +71,8 @@ pub mod cp_amm {
         instructions::handle_close_config(ctx)
     }
 
-    pub fn initialize_reward<'c: 'info, 'info>(
-        ctx: Context<'_, '_, 'c, 'info, InitializeRewardCtx<'info>>,
+    pub fn initialize_reward(
+        ctx: CorrectContext<InitializeRewardCtx>,
         reward_index: u8,
         reward_duration: u64,
         funder: Pubkey,
@@ -136,22 +138,22 @@ pub mod cp_amm {
 
     /// USER FUNCTIONS ////
 
-    pub fn initialize_pool<'c: 'info, 'info>(
-        ctx: Context<'_, '_, 'c, 'info, InitializePoolCtx<'info>>,
+    pub fn initialize_pool(
+        ctx: CorrectContext<InitializePoolCtx>,
         params: InitializePoolParameters,
     ) -> Result<()> {
         instructions::handle_initialize_pool(ctx, params)
     }
 
-    pub fn initialize_pool_with_dynamic_config<'c: 'info, 'info>(
-        ctx: Context<'_, '_, 'c, 'info, InitializePoolWithDynamicConfigCtx<'info>>,
+    pub fn initialize_pool_with_dynamic_config(
+        ctx: CorrectContext<InitializePoolWithDynamicConfigCtx>,
         params: InitializeCustomizablePoolParameters,
     ) -> Result<()> {
         instructions::handle_initialize_pool_with_dynamic_config(ctx, params)
     }
 
-    pub fn initialize_customizable_pool<'c: 'info, 'info>(
-        ctx: Context<'_, '_, 'c, 'info, InitializeCustomizablePoolCtx<'info>>,
+    pub fn initialize_customizable_pool(
+        ctx: CorrectContext<InitializeCustomizablePoolCtx>,
         params: InitializeCustomizablePoolParameters,
     ) -> Result<()> {
         instructions::handle_initialize_customizable_pool(ctx, params)
@@ -197,7 +199,7 @@ pub mod cp_amm {
         instructions::handle_close_position(ctx)
     }
 
-    pub fn swap(ctx: Context<SwapCtx>, params: SwapParameters) -> Result<()> {
+    pub fn swap(ctx: CorrectContext<SwapCtx>, params: SwapParameters) -> Result<()> {
         instructions::swap::handle_swap_wrapper(
             &ctx,
             SwapParameters2 {
@@ -208,7 +210,7 @@ pub mod cp_amm {
         )
     }
 
-    pub fn swap2(ctx: Context<SwapCtx>, params: SwapParameters2) -> Result<()> {
+    pub fn swap2(ctx: CorrectContext<SwapCtx>, params: SwapParameters2) -> Result<()> {
         instructions::swap::handle_swap_wrapper(&ctx, params)
     }
 
@@ -220,8 +222,8 @@ pub mod cp_amm {
         instructions::handle_lock_position(ctx, params)
     }
 
-    pub fn refresh_vesting<'a, 'b, 'c: 'info, 'info>(
-        ctx: Context<'a, 'b, 'c, 'info, RefreshVesting<'info>>,
+    pub fn refresh_vesting<'info>(
+        ctx: CorrectContext<'_, '_, 'info, RefreshVesting<'info>>,
     ) -> Result<()> {
         instructions::handle_refresh_vesting(ctx)
     }

--- a/programs/cp-amm/src/tests/swap_tests.rs
+++ b/programs/cp-amm/src/tests/swap_tests.rs
@@ -205,7 +205,12 @@ fn test_swap_basic() {
     pool.apply_swap_result(&swap_result, fee_mode, 0).unwrap();
 
     let swap_result_referse = pool
-        .get_swap_result_from_exact_input(swap_result.output_amount, fee_mode, TradeDirection::BtoA, 0)
+        .get_swap_result_from_exact_input(
+            swap_result.output_amount,
+            fee_mode,
+            TradeDirection::BtoA,
+            0,
+        )
         .unwrap();
 
     println!("reverse {:?}", swap_result_referse);

--- a/programs/cp-amm/src/utils/token.rs
+++ b/programs/cp-amm/src/utils/token.rs
@@ -151,7 +151,7 @@ pub fn get_epoch_transfer_fee<'info>(
     Ok(None)
 }
 
-pub fn transfer_from_user<'a, 'c: 'info, 'info>(
+pub fn transfer_from_user<'a, 'info>(
     authority: &'a Signer<'info>,
     token_mint: &'a InterfaceAccount<'info, Mint>,
     token_owner_account: &'a InterfaceAccount<'info, TokenAccount>,
@@ -184,7 +184,7 @@ pub fn transfer_from_user<'a, 'c: 'info, 'info>(
     Ok(())
 }
 
-pub fn transfer_from_pool<'c: 'info, 'info>(
+pub fn transfer_from_pool<'info>(
     pool_authority: AccountInfo<'info>,
     token_mint: &InterfaceAccount<'info, Mint>,
     token_vault: &InterfaceAccount<'info, TokenAccount>,
@@ -258,9 +258,9 @@ pub fn is_supported_mint(mint_account: &InterfaceAccount<Mint>) -> Result<bool> 
     Ok(true)
 }
 
-pub fn is_token_badge_initialized<'c: 'info, 'info>(
+pub fn is_token_badge_initialized<'info>(
     mint: Pubkey,
-    token_badge: &'c AccountInfo<'info>,
+    token_badge: &'info AccountInfo<'info>,
 ) -> Result<bool> {
     let token_badge: AccountLoader<'_, TokenBadge> = AccountLoader::try_from(token_badge)?;
     let token_badge = token_badge.load()?;


### PR DESCRIPTION
Simplify lifetime declarations by using the following type definition:
```Rust
pub type CorrectContext<'a, 'b, 'info, T> = Context<'a, 'b, 'info, 'info, T>;
```