### PR TITLE
Harden DAMM pool init badge indexing and compounding consistency

### DIFF
--- a/programs/cp-amm/Cargo.toml
+++ b/programs/cp-amm/Cargo.toml
@@ -17,6 +17,7 @@ cpi = ["no-entrypoint", "no-custom-entrypoint"]
 default = ["no-entrypoint"]
 local = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
+rate-limiter-stack-whitelist = []
 
 [dependencies]
 anchor-lang = { workspace = true, features = ["event-cpi"] }

--- a/programs/cp-amm/src/constants.rs
+++ b/programs/cp-amm/src/constants.rs
@@ -1,5 +1,6 @@
 use anchor_lang::constant;
-use anchor_lang::prelude::*;
+#[cfg(feature = "rate-limiter-stack-whitelist")]
+use anchor_lang::prelude::Pubkey;
 
 pub const MIN_SQRT_PRICE: u128 = 4295048016;
 
@@ -61,10 +62,14 @@ static_assertions::const_assert_eq!(
     MAX_RATE_LIMITER_DURATION_IN_SLOTS
 );
 
+#[cfg(feature = "rate-limiter-stack-whitelist")]
 const OKX_SMART_WALLET: Pubkey =
     Pubkey::from_str_const("va1t8sdGkReA6XFgAeZGXmdQoiEtMirwy4ifLv7yGdH");
 
+#[cfg(feature = "rate-limiter-stack-whitelist")]
 pub const RATE_LIMITER_STACK_WHITELIST_PROGRAMS: [[u8; 32]; 1] = [OKX_SMART_WALLET.to_bytes()];
+#[cfg(not(feature = "rate-limiter-stack-whitelist"))]
+pub const RATE_LIMITER_STACK_WHITELIST_PROGRAMS: [[u8; 32]; 0] = [];
 
 pub mod activation {
     #[cfg(not(feature = "local"))]

--- a/programs/cp-amm/src/instructions/initialize_pool/ix_initialize_customizable_pool.rs
+++ b/programs/cp-amm/src/instructions/initialize_pool/ix_initialize_customizable_pool.rs
@@ -26,7 +26,7 @@ use crate::{
     EvtCreatePosition, EvtInitializePool, InitialPoolInformation, PoolError,
 };
 
-use super::{max_key, min_key};
+use super::{max_key, min_key, required_badge_indices};
 
 #[derive(AnchorSerialize, AnchorDeserialize)]
 pub struct InitializeCustomizablePoolParameters {
@@ -253,24 +253,29 @@ pub fn handle_initialize_customizable_pool<'c: 'info, 'info>(
     params: InitializeCustomizablePoolParameters,
 ) -> Result<()> {
     params.validate()?;
-    if !is_supported_mint(&ctx.accounts.token_a_mint)? {
+    let token_a_requires_badge = !is_supported_mint(&ctx.accounts.token_a_mint)?;
+    let token_b_requires_badge = !is_supported_mint(&ctx.accounts.token_b_mint)?;
+    let (token_a_badge_idx, token_b_badge_idx) =
+        required_badge_indices(token_a_requires_badge, token_b_requires_badge);
+
+    if token_a_requires_badge {
         require!(
             is_token_badge_initialized(
                 ctx.accounts.token_a_mint.key(),
                 ctx.remaining_accounts
-                    .get(0)
+                    .get(token_a_badge_idx.ok_or(PoolError::InvalidTokenBadge)?)
                     .ok_or(PoolError::InvalidTokenBadge)?,
             )?,
             PoolError::InvalidTokenBadge
         )
     }
 
-    if !is_supported_mint(&ctx.accounts.token_b_mint)? {
+    if token_b_requires_badge {
         require!(
             is_token_badge_initialized(
                 ctx.accounts.token_b_mint.key(),
                 ctx.remaining_accounts
-                    .get(1)
+                    .get(token_b_badge_idx.ok_or(PoolError::InvalidTokenBadge)?)
                     .ok_or(PoolError::InvalidTokenBadge)?,
             )?,
             PoolError::InvalidTokenBadge

--- a/programs/cp-amm/src/instructions/initialize_pool/ix_initialize_pool.rs
+++ b/programs/cp-amm/src/instructions/initialize_pool/ix_initialize_pool.rs
@@ -8,6 +8,7 @@ use std::{
     u64,
 };
 
+use super::required_badge_indices;
 use crate::{
     activation_handler::ActivationHandler,
     const_pda,
@@ -187,24 +188,29 @@ pub fn handle_initialize_pool<'c: 'info, 'info>(
     ctx: Context<'_, '_, 'c, 'info, InitializePoolCtx<'info>>,
     params: InitializePoolParameters,
 ) -> Result<()> {
-    if !is_supported_mint(&ctx.accounts.token_a_mint)? {
+    let token_a_requires_badge = !is_supported_mint(&ctx.accounts.token_a_mint)?;
+    let token_b_requires_badge = !is_supported_mint(&ctx.accounts.token_b_mint)?;
+    let (token_a_badge_idx, token_b_badge_idx) =
+        required_badge_indices(token_a_requires_badge, token_b_requires_badge);
+
+    if token_a_requires_badge {
         require!(
             is_token_badge_initialized(
                 ctx.accounts.token_a_mint.key(),
                 ctx.remaining_accounts
-                    .get(0)
+                    .get(token_a_badge_idx.ok_or(PoolError::InvalidTokenBadge)?)
                     .ok_or(PoolError::InvalidTokenBadge)?,
             )?,
             PoolError::InvalidTokenBadge
         )
     }
 
-    if !is_supported_mint(&ctx.accounts.token_b_mint)? {
+    if token_b_requires_badge {
         require!(
             is_token_badge_initialized(
                 ctx.accounts.token_b_mint.key(),
                 ctx.remaining_accounts
-                    .get(1)
+                    .get(token_b_badge_idx.ok_or(PoolError::InvalidTokenBadge)?)
                     .ok_or(PoolError::InvalidTokenBadge)?,
             )?,
             PoolError::InvalidTokenBadge

--- a/programs/cp-amm/src/instructions/initialize_pool/ix_initialize_pool_with_dynamic_config.rs
+++ b/programs/cp-amm/src/instructions/initialize_pool/ix_initialize_pool_with_dynamic_config.rs
@@ -21,7 +21,7 @@ use crate::{
     InitializeCustomizablePoolParameters, PoolError,
 };
 
-use super::{max_key, min_key};
+use super::{max_key, min_key, required_badge_indices};
 
 #[event_cpi]
 #[derive(Accounts)]
@@ -169,24 +169,29 @@ pub fn handle_initialize_pool_with_dynamic_config<'c: 'info, 'info>(
     params: InitializeCustomizablePoolParameters,
 ) -> Result<()> {
     params.validate()?;
-    if !is_supported_mint(&ctx.accounts.token_a_mint)? {
+    let token_a_requires_badge = !is_supported_mint(&ctx.accounts.token_a_mint)?;
+    let token_b_requires_badge = !is_supported_mint(&ctx.accounts.token_b_mint)?;
+    let (token_a_badge_idx, token_b_badge_idx) =
+        required_badge_indices(token_a_requires_badge, token_b_requires_badge);
+
+    if token_a_requires_badge {
         require!(
             is_token_badge_initialized(
                 ctx.accounts.token_a_mint.key(),
                 ctx.remaining_accounts
-                    .get(0)
+                    .get(token_a_badge_idx.ok_or(PoolError::InvalidTokenBadge)?)
                     .ok_or(PoolError::InvalidTokenBadge)?,
             )?,
             PoolError::InvalidTokenBadge
         )
     }
 
-    if !is_supported_mint(&ctx.accounts.token_b_mint)? {
+    if token_b_requires_badge {
         require!(
             is_token_badge_initialized(
                 ctx.accounts.token_b_mint.key(),
                 ctx.remaining_accounts
-                    .get(1)
+                    .get(token_b_badge_idx.ok_or(PoolError::InvalidTokenBadge)?)
                     .ok_or(PoolError::InvalidTokenBadge)?,
             )?,
             PoolError::InvalidTokenBadge

--- a/programs/cp-amm/src/instructions/initialize_pool/mod.rs
+++ b/programs/cp-amm/src/instructions/initialize_pool/mod.rs
@@ -4,3 +4,52 @@ pub mod ix_initialize_customizable_pool;
 pub use ix_initialize_customizable_pool::*;
 pub mod ix_initialize_pool_with_dynamic_config;
 pub use ix_initialize_pool_with_dynamic_config::*;
+
+pub(crate) fn required_badge_indices(
+    token_a_requires_badge: bool,
+    token_b_requires_badge: bool,
+) -> (Option<usize>, Option<usize>) {
+    let mut next_idx = 0usize;
+    let token_a_badge_idx = if token_a_requires_badge {
+        let idx = next_idx;
+        next_idx += 1;
+        Some(idx)
+    } else {
+        None
+    };
+    let token_b_badge_idx = if token_b_requires_badge {
+        Some(next_idx)
+    } else {
+        None
+    };
+    (token_a_badge_idx, token_b_badge_idx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::required_badge_indices;
+
+    #[test]
+    fn badge_indices_when_no_badges_needed() {
+        let indices = required_badge_indices(false, false);
+        assert_eq!(indices, (None, None));
+    }
+
+    #[test]
+    fn badge_indices_when_only_token_a_needs_badge() {
+        let indices = required_badge_indices(true, false);
+        assert_eq!(indices, (Some(0), None));
+    }
+
+    #[test]
+    fn badge_indices_when_only_token_b_needs_badge() {
+        let indices = required_badge_indices(false, true);
+        assert_eq!(indices, (None, Some(0)));
+    }
+
+    #[test]
+    fn badge_indices_when_both_tokens_need_badges() {
+        let indices = required_badge_indices(true, true);
+        assert_eq!(indices, (Some(0), Some(1)));
+    }
+}

--- a/programs/cp-amm/src/pool_action_access/permissionless.rs
+++ b/programs/cp-amm/src/pool_action_access/permissionless.rs
@@ -44,7 +44,7 @@ impl PoolActionAccess for PermissionlessActionAccess {
     }
 
     fn can_remove_liquidity(&self) -> bool {
-        self.current_point >= self.activation_point
+        self.is_enabled && self.current_point >= self.activation_point
     }
 
     fn can_swap(&self, sender: &Pubkey) -> bool {
@@ -67,5 +67,38 @@ impl PoolActionAccess for PermissionlessActionAccess {
     }
     fn can_split_position(&self) -> bool {
         self.is_enabled
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn access(is_enabled: bool, current_point: u64, activation_point: u64) -> PermissionlessActionAccess {
+        PermissionlessActionAccess {
+            is_enabled,
+            activation_point,
+            pre_activation_point: activation_point.saturating_sub(1),
+            current_point,
+            whitelisted_vault: Pubkey::default(),
+        }
+    }
+
+    #[test]
+    fn remove_liquidity_requires_pool_enabled() {
+        let access = access(false, 10, 0);
+        assert!(!access.can_remove_liquidity());
+    }
+
+    #[test]
+    fn remove_liquidity_requires_activation_reached() {
+        let access = access(true, 9, 10);
+        assert!(!access.can_remove_liquidity());
+    }
+
+    #[test]
+    fn remove_liquidity_allowed_when_enabled_and_activated() {
+        let access = access(true, 10, 10);
+        assert!(access.can_remove_liquidity());
     }
 }

--- a/programs/cp-amm/src/state/pool.rs
+++ b/programs/cp-amm/src/state/pool.rs
@@ -874,6 +874,7 @@ impl Pool {
         self.liquidity = self.liquidity.safe_add(liquidity_delta)?;
         self.token_a_amount = self.token_a_amount.safe_add(token_a_amount)?;
         self.token_b_amount = self.token_b_amount.safe_add(token_b_amount)?;
+        self.sync_sqrt_price_from_reserves()?;
 
         Ok(())
     }
@@ -895,7 +896,14 @@ impl Pool {
         self.liquidity = self.liquidity.safe_sub(liquidity_delta)?;
         self.token_a_amount = self.token_a_amount.safe_sub(token_a_amount)?;
         self.token_b_amount = self.token_b_amount.safe_sub(token_b_amount)?;
+        self.sync_sqrt_price_from_reserves()?;
 
+        Ok(())
+    }
+
+    fn sync_sqrt_price_from_reserves(&mut self) -> Result<()> {
+        let liquidity_handler = self.get_liquidity_handler()?;
+        self.sqrt_price = liquidity_handler.get_next_sqrt_price(self.sqrt_price)?;
         Ok(())
     }
 

--- a/programs/cp-amm/src/tests/test_modify_liquidity.rs
+++ b/programs/cp-amm/src/tests/test_modify_liquidity.rs
@@ -1,8 +1,10 @@
 use crate::{
     constants::{MAX_SQRT_PRICE, MIN_SQRT_PRICE},
-    state::{Pool, Position},
+    get_initial_pool_information,
+    state::{CollectFeeMode, Pool, Position},
     tests::LIQUIDITY_MAX,
     u128x128_math::Rounding,
+    CompoundingLiquidity, InitialPoolInformation, LiquidityHandler,
 };
 use proptest::prelude::*;
 
@@ -45,4 +47,73 @@ proptest! {
         assert!(result_0.0 >= result_1.0);
         assert!(result_0.1 >= result_1.1);
     }
+}
+
+#[test]
+fn test_compounding_modify_liquidity_syncs_sqrt_price_from_reserves() {
+    let (sqrt_price, liquidity) =
+        super::test_liquidity_compounding::get_sqrt_price_and_liquidity_from_amounts(
+            100_000_000,
+            100_000_000_000,
+        )
+        .unwrap();
+
+    let InitialPoolInformation {
+        token_a_amount,
+        token_b_amount,
+        initial_liquidity,
+        ..
+    } = get_initial_pool_information(CollectFeeMode::Compounding, 0, 0, sqrt_price, liquidity)
+        .unwrap();
+
+    let mut pool = Pool {
+        collect_fee_mode: CollectFeeMode::Compounding.into(),
+        token_a_amount,
+        token_b_amount,
+        liquidity,
+        sqrt_price,
+        ..Default::default()
+    };
+    let mut position = Position {
+        unlocked_liquidity: initial_liquidity,
+        ..Default::default()
+    };
+
+    let add_delta = 1u128;
+    let (add_a, add_b) = pool
+        .get_liquidity_handler()
+        .unwrap()
+        .get_amounts_for_modify_liquidity(add_delta, Rounding::Up)
+        .unwrap();
+    let sqrt_before_add = pool.sqrt_price;
+    let expected_after_add = CompoundingLiquidity {
+        token_a_amount: pool.token_a_amount + add_a,
+        token_b_amount: pool.token_b_amount + add_b,
+        liquidity: pool.liquidity + add_delta,
+    }
+    .get_next_sqrt_price(sqrt_before_add)
+    .unwrap();
+
+    pool.apply_add_liquidity(&mut position, add_delta, add_a, add_b)
+        .unwrap();
+    assert_eq!(pool.sqrt_price, expected_after_add);
+
+    let remove_delta = add_delta;
+    let (remove_a, remove_b) = pool
+        .get_liquidity_handler()
+        .unwrap()
+        .get_amounts_for_modify_liquidity(remove_delta, Rounding::Down)
+        .unwrap();
+    let sqrt_before_remove = pool.sqrt_price;
+    let expected_after_remove = CompoundingLiquidity {
+        token_a_amount: pool.token_a_amount - remove_a,
+        token_b_amount: pool.token_b_amount - remove_b,
+        liquidity: pool.liquidity - remove_delta,
+    }
+    .get_next_sqrt_price(sqrt_before_remove)
+    .unwrap();
+
+    pool.apply_remove_liquidity(&mut position, remove_delta, remove_a, remove_b)
+        .unwrap();
+    assert_eq!(pool.sqrt_price, expected_after_remove);
 }


### PR DESCRIPTION
## Summary
- Replace fixed token-badge account assumptions with deterministic index derivation from the unsupported mint set during pool initialization.
- Feature-gate stack-height whitelist behavior behind explicit `rate-limiter-stack-whitelist` opt-in builds.
- Sync `sqrt_price` after compounding liquidity add/remove operations and tighten permissionless remove-liquidity access checks with targeted tests.

## Test plan
- [x] `cargo test -p cp-amm`
- [x] `cargo test -p cp-amm --features rate-limiter-stack-whitelist --no-run`

Made with [Cursor](https://cursor.com)