### PR TITLE
fix: withdrawing_dead_liquidity_reward & dead_liquidity_reward no longer carry forward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
-- `fund_reward` on a `CollectFeeMode::Compounding` pool now requires the pending dead-liquidity reward to be zero. Previously the funder could `fund_reward` mid-campaign on compounding pools. Now they must call `withdraw_dead_liquidity_reward` first, this must be bundled in the same transaction as `fund_reward` since the reward accrues every second. After the campaign ends, no bundling is needed.
 - Renamed the signer account from `owner` to `signer`, now that the signer may be a delegate, in the following endpoints: `claim_position_fee`, `claim_reward`, `add_liquidity`, `remove_liquidity`, `remove_all_liquidity`, `lock_position`, `lock_inner_position`, `permanent_lock_position`.
 - The following endpoints previously rejected unauthorized signers with Anchor's `ConstraintTokenOwner` (2015) and now reject with `PoolError::InvalidAuthority` (6053), `PoolError::InvalidPermission` (6054), or `PoolError::DelegatedAmountNonZero` (6070): `claim_position_fee`, `claim_reward`, `add_liquidity`, `remove_liquidity`, `remove_all_liquidity`, `lock_position`, `lock_inner_position`, `permanent_lock_position`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,19 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added support for NFT delegates to manage positions. The following endpoints can now be signed by a delegate if the owner has granted them permission: `claim_position_fee`, `claim_reward`, `add_liquidity`, `remove_liquidity`, `remove_all_liquidity`, `lock_position`, `lock_inner_position`, `permanent_lock_position`. Note: the `close_position`, `split_position`, and `split_position2` endpoints remain callable by the owner only.
 - Added new endpoint `update_delegate_permission` to set the permission bitmask on `Position.delegate_permission`. Pass `permission = 0` to clear all permissions. Callers are responsible for managing the SPL token delegate via SPL `Approve` / `Revoke` separately. The bitmask supports 8 permissions: `AddLiquidity`, `RemoveLiquidity`, `RemoveLiquidityToOwner`, `ClaimPositionFee`, `ClaimPositionFeeToOwner`, `ClaimReward`, `ClaimRewardToOwner`, `LockPosition`.
-- Added new endpoint `withdraw_dead_liquidity_reward` allowing the funder to recover the unowned `DEAD_LIQUIDITY` reward share of a `CollectFeeMode::Compounding` pool at any time, without waiting for the reward campaign to end. This share is tracked by the new `dead_liquidity_reward_checkpoint` field in the Pool `RewardInfo`. See the related entry under `Fixed` below.
+- Added new endpoint `withdraw_dead_liquidity_reward` allowing the funder to recover the unowned `DEAD_LIQUIDITY` reward share of a `CollectFeeMode::Compounding` pool at any time, without waiting for the reward campaign to end. This share is tracked by the new `dead_liquidity_reward_checkpoint` field in the Pool `RewardInfo`.
 
 ### Changed
 
-- Events `EvtClaimPositionFee`, `EvtClaimReward`, `EvtLiquidityChange` and `EvtLockPosition` now source the `owner` field from `position_nft_account.owner` instead of the signer, since the signer can now be a delegate.
-
-### Fixed
-
-- Fixed reward accounting for the unowned `DEAD_LIQUIDITY` share in `CollectFeeMode::Compounding` pools. This liquidity is part of `liquidity_supply` but is not owned by any position, so its reward share was previously stranded in the reward vault. That share can now be recovered via `withdraw_dead_liquidity_reward`.
+- Renamed the signer account from `owner` to `signer`, now that the signer may be a delegate, in the following endpoints: `claim_position_fee`, `claim_reward`, `add_liquidity`, `remove_liquidity`, `remove_all_liquidity`, `lock_position`, `lock_inner_position`, `permanent_lock_position`.
 
 ### Breaking Changes
 
-- Renamed the signer account from `owner` to `signer`, now that the signer may be a delegate, in the following endpoints: `claim_position_fee`, `claim_reward`, `add_liquidity`, `remove_liquidity`, `remove_all_liquidity`, `lock_position`, `lock_inner_position`, `permanent_lock_position`.
 - The following endpoints previously rejected unauthorized signers with Anchor's `ConstraintTokenOwner` (2015) and now reject with `PoolError::InvalidAuthority` (6053), `PoolError::InvalidPermission` (6054), or `PoolError::DelegatedAmountNonZero` (6070): `claim_position_fee`, `claim_reward`, `add_liquidity`, `remove_liquidity`, `remove_all_liquidity`, `lock_position`, `lock_inner_position`, `permanent_lock_position`.
 
 ## cp_amm [0.2.1][#PR 200](https://github.com/MeteoraAg/damm-v2/pull/200)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added support for NFT delegates to manage positions. The following endpoints can now be signed by a delegate if the owner has granted them permission: `claim_position_fee`, `claim_reward`, `add_liquidity`, `remove_liquidity`, `remove_all_liquidity`, `lock_position`, `lock_inner_position`, `permanent_lock_position`. Note: the `close_position`, `split_position`, and `split_position2` endpoints remain callable by the owner only.
 - Added new endpoint `update_delegate_permission` to set the permission bitmask on `Position.delegate_permission`. Pass `permission = 0` to clear all permissions. Callers are responsible for managing the SPL token delegate via SPL `Approve` / `Revoke` separately. The bitmask supports 8 permissions: `AddLiquidity`, `RemoveLiquidity`, `RemoveLiquidityToOwner`, `ClaimPositionFee`, `ClaimPositionFeeToOwner`, `ClaimReward`, `ClaimRewardToOwner`, `LockPosition`.
-- Added new field `dead_liquidity_reward_checkpoint` in Pool `RewardInfo` to track the unowned `DEAD_LIQUIDITY` reward share. See the related entry under `Fixed` below.
+- Added new endpoint `withdraw_dead_liquidity_reward` allowing the funder to recover the unowned `DEAD_LIQUIDITY` reward share of a `CollectFeeMode::Compounding` pool at any time, without waiting for the reward campaign to end. This share is tracked by the new `dead_liquidity_reward_checkpoint` field in the Pool `RewardInfo`. See the related entry under `Fixed` below.
 
 ### Changed
 
@@ -33,10 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed reward accounting for the unowned `DEAD_LIQUIDITY` share in `CollectFeeMode::Compounding` pools. This liquidity is part of `liquidity_supply` but is not owned by any position, so its reward share was previously stranded in the reward vault. It is now accrued as an ineligible reward that the funder can recover via `withdraw_ineligible_reward`, or carry it forward when calling `fund_reward` with `carry_forward = true`.
+- Fixed reward accounting for the unowned `DEAD_LIQUIDITY` share in `CollectFeeMode::Compounding` pools. This liquidity is part of `liquidity_supply` but is not owned by any position, so its reward share was previously stranded in the reward vault. That share can now be recovered via `withdraw_dead_liquidity_reward`.
 
 ### Breaking Changes
 
+- `fund_reward` on a `CollectFeeMode::Compounding` pool now requires the pending dead-liquidity reward to be zero. Previously the funder could `fund_reward` mid-campaign on compounding pools. Now they must call `withdraw_dead_liquidity_reward` first, this must be bundled in the same transaction as `fund_reward` since the reward accrues every second. After the campaign ends, no bundling is needed.
 - Renamed the signer account from `owner` to `signer`, now that the signer may be a delegate, in the following endpoints: `claim_position_fee`, `claim_reward`, `add_liquidity`, `remove_liquidity`, `remove_all_liquidity`, `lock_position`, `lock_inner_position`, `permanent_lock_position`.
 - The following endpoints previously rejected unauthorized signers with Anchor's `ConstraintTokenOwner` (2015) and now reject with `PoolError::InvalidAuthority` (6053), `PoolError::InvalidPermission` (6054), or `PoolError::DelegatedAmountNonZero` (6070): `claim_position_fee`, `claim_reward`, `add_liquidity`, `remove_liquidity`, `remove_all_liquidity`, `lock_position`, `lock_inner_position`, `permanent_lock_position`.
 

--- a/programs/cp-amm/src/error.rs
+++ b/programs/cp-amm/src/error.rs
@@ -218,9 +218,6 @@ pub enum PoolError {
 
     #[msg("Delegated amount is not zero")]
     DelegatedAmountNonZero,
-
-    #[msg("Must withdraw dead liquidity reward")]
-    MustWithdrawDeadLiquidityReward,
 }
 
 impl From<ProtozolZapError> for PoolError {

--- a/programs/cp-amm/src/error.rs
+++ b/programs/cp-amm/src/error.rs
@@ -218,6 +218,9 @@ pub enum PoolError {
 
     #[msg("Delegated amount is not zero")]
     DelegatedAmountNonZero,
+
+    #[msg("Must withdraw dead liquidity reward")]
+    MustWithdrawDeadLiquidityReward,
 }
 
 impl From<ProtozolZapError> for PoolError {

--- a/programs/cp-amm/src/event.rs
+++ b/programs/cp-amm/src/event.rs
@@ -251,6 +251,13 @@ pub struct EvtWithdrawIneligibleReward {
     pub amount: u64,
 }
 
+#[event]
+pub struct EvtWithdrawDeadLiquidityReward {
+    pub pool: Pubkey,
+    pub reward_mint: Pubkey,
+    pub amount: u64,
+}
+
 #[deprecated(since = "0.1.8", note = "Use EvtSplitPosition3 instead")]
 #[event]
 pub struct EvtSplitPosition2 {

--- a/programs/cp-amm/src/instructions/ix_fund_reward.rs
+++ b/programs/cp-amm/src/instructions/ix_fund_reward.rs
@@ -84,6 +84,12 @@ pub fn handle_fund_reward(
     let reward_info = &mut pool.reward_infos[index];
     let pre_reward_rate = reward_info.reward_rate;
 
+    // force withdrawal of pending dead_liquidity_reward first, so the wrapped checkpoint delta stays below 2^64
+    require!(
+        reward_info.get_pending_dead_liquidity_reward(collect_fee_mode)? == 0,
+        PoolError::MustWithdrawDeadLiquidityReward
+    );
+
     let total_amount = if carry_forward {
         let carry_forward_ineligible_reward: u64 = safe_mul_shr_cast(
             reward_info.reward_rate,
@@ -97,21 +103,13 @@ pub fn handle_fund_reward(
         // because it will be brought forward to next reward window
         reward_info.cumulative_seconds_with_empty_liquidity_reward = 0;
 
-        // carry forward dead liquidity reward
-        let dead_liquidity_reward = reward_info.settle_dead_liquidity_reward(collect_fee_mode)?;
-
-        transfer_fee_excluded_amount_in
-            .safe_add(carry_forward_ineligible_reward)?
-            .safe_add(dead_liquidity_reward)?
+        transfer_fee_excluded_amount_in.safe_add(carry_forward_ineligible_reward)?
     } else {
         // Because the program only keep track of cumulative seconds of rewards with empty liquidity,
         // and funding will affect the reward rate, which directly affect ineligible reward calculation.
         // ineligible_reward = reward_rate_per_seconds * cumulative_seconds_with_empty_liquidity_reward
-        //
-        // force withdrawal of pending dead_liquidity_reward first, so the wrapped checkpoint delta stays below 2^64
         require!(
-            reward_info.cumulative_seconds_with_empty_liquidity_reward == 0
-                && reward_info.get_pending_dead_liquidity_reward(collect_fee_mode)? == 0,
+            reward_info.cumulative_seconds_with_empty_liquidity_reward == 0,
             PoolError::MustWithdrawnIneligibleReward
         );
 

--- a/programs/cp-amm/src/instructions/ix_fund_reward.rs
+++ b/programs/cp-amm/src/instructions/ix_fund_reward.rs
@@ -4,8 +4,8 @@ use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
 use crate::{
     constants::{NUM_REWARDS, REWARD_RATE_SCALE},
     event::EvtFundReward,
-    math::safe_math::{SafeCast, SafeMath},
-    state::{CollectFeeMode, Pool},
+    math::safe_math::SafeMath,
+    state::Pool,
     token::{calculate_transfer_fee_excluded_amount, transfer_from_user},
     utils_math::safe_mul_shr_cast,
     PoolError,
@@ -76,19 +76,12 @@ pub fn handle_fund_reward(
 
     let mut pool = ctx.accounts.pool.load_mut()?;
     let current_time = Clock::get()?.unix_timestamp;
-    let collect_fee_mode: CollectFeeMode = pool.collect_fee_mode.safe_cast()?;
     // 1. update pool rewards
     pool.update_rewards(current_time as u64)?;
 
     // 2. set new farming rate
     let reward_info = &mut pool.reward_infos[index];
     let pre_reward_rate = reward_info.reward_rate;
-
-    // force withdrawal of pending dead_liquidity_reward first, so the wrapped checkpoint delta stays below 2^64
-    require!(
-        reward_info.get_pending_dead_liquidity_reward(collect_fee_mode)? == 0,
-        PoolError::MustWithdrawDeadLiquidityReward
-    );
 
     let total_amount = if carry_forward {
         let carry_forward_ineligible_reward: u64 = safe_mul_shr_cast(

--- a/programs/cp-amm/src/instructions/ix_withdraw_dead_liquidity_reward.rs
+++ b/programs/cp-amm/src/instructions/ix_withdraw_dead_liquidity_reward.rs
@@ -1,0 +1,100 @@
+use anchor_lang::prelude::*;
+use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
+
+use crate::{
+    const_pda, constants::NUM_REWARDS, error::PoolError, event::EvtWithdrawDeadLiquidityReward,
+    math::safe_math::SafeCast, state::pool::Pool, state::CollectFeeMode, token::transfer_from_pool,
+};
+
+#[event_cpi]
+#[derive(Accounts)]
+pub struct WithdrawDeadLiquidityRewardCtx<'info> {
+    /// CHECK: pool authority
+    #[account(address = const_pda::pool_authority::ID)]
+    pub pool_authority: UncheckedAccount<'info>,
+
+    #[account(mut)]
+    pub pool: AccountLoader<'info, Pool>,
+
+    #[account(mut)]
+    pub reward_vault: Box<InterfaceAccount<'info, TokenAccount>>,
+
+    pub reward_mint: Box<InterfaceAccount<'info, Mint>>,
+
+    #[account(mut)]
+    pub funder_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
+
+    pub funder: Signer<'info>,
+
+    pub token_program: Interface<'info, TokenInterface>,
+}
+
+impl<'info> WithdrawDeadLiquidityRewardCtx<'info> {
+    fn validate(&self, reward_index: usize) -> Result<()> {
+        let pool = self.pool.load()?;
+        require!(reward_index < NUM_REWARDS, PoolError::InvalidRewardIndex);
+
+        let collect_fee_mode: CollectFeeMode = pool.collect_fee_mode.safe_cast()?;
+        require!(
+            collect_fee_mode == CollectFeeMode::Compounding,
+            PoolError::InvalidCollectFeeMode
+        );
+
+        let reward_info = &pool.reward_infos[reward_index];
+
+        require!(reward_info.initialized(), PoolError::RewardUninitialized);
+
+        require!(
+            reward_info.vault.eq(&self.reward_vault.key()),
+            PoolError::InvalidRewardVault
+        );
+
+        require!(
+            reward_info.is_valid_funder(self.funder.key()),
+            PoolError::InvalidFunder
+        );
+
+        Ok(())
+    }
+}
+
+pub fn handle_withdraw_dead_liquidity_reward(
+    ctx: Context<WithdrawDeadLiquidityRewardCtx>,
+    reward_index: u8,
+) -> Result<()> {
+    let index: usize = reward_index
+        .try_into()
+        .map_err(|_| PoolError::TypeCastFailed)?;
+    ctx.accounts.validate(index)?;
+
+    let mut pool = ctx.accounts.pool.load_mut()?;
+
+    let current_time = Clock::get()?.unix_timestamp as u64;
+
+    // update pool reward
+    pool.update_rewards(current_time)?;
+
+    let collect_fee_mode: CollectFeeMode = pool.collect_fee_mode.safe_cast()?;
+    let dead_liquidity_reward =
+        pool.reward_infos[index].claim_dead_liquidity_reward(collect_fee_mode)?;
+
+    // transfer rewards to funder
+    if dead_liquidity_reward > 0 {
+        transfer_from_pool(
+            ctx.accounts.pool_authority.to_account_info(),
+            &ctx.accounts.reward_mint,
+            &ctx.accounts.reward_vault,
+            &ctx.accounts.funder_token_account.to_account_info(),
+            &ctx.accounts.token_program,
+            dead_liquidity_reward,
+        )?;
+    }
+
+    emit_cpi!(EvtWithdrawDeadLiquidityReward {
+        amount: dead_liquidity_reward,
+        pool: ctx.accounts.pool.key(),
+        reward_mint: ctx.accounts.reward_mint.key(),
+    });
+
+    Ok(())
+}

--- a/programs/cp-amm/src/instructions/ix_withdraw_dead_liquidity_reward.rs
+++ b/programs/cp-amm/src/instructions/ix_withdraw_dead_liquidity_reward.rs
@@ -88,13 +88,13 @@ pub fn handle_withdraw_dead_liquidity_reward(
             &ctx.accounts.token_program,
             dead_liquidity_reward,
         )?;
-    }
 
-    emit_cpi!(EvtWithdrawDeadLiquidityReward {
-        amount: dead_liquidity_reward,
-        pool: ctx.accounts.pool.key(),
-        reward_mint: ctx.accounts.reward_mint.key(),
-    });
+        emit_cpi!(EvtWithdrawDeadLiquidityReward {
+            amount: dead_liquidity_reward,
+            pool: ctx.accounts.pool.key(),
+            reward_mint: ctx.accounts.reward_mint.key(),
+        });
+    }
 
     Ok(())
 }

--- a/programs/cp-amm/src/instructions/mod.rs
+++ b/programs/cp-amm/src/instructions/mod.rs
@@ -26,6 +26,8 @@ pub mod ix_fund_reward;
 pub use ix_fund_reward::*;
 pub mod ix_withdraw_ineligible_reward;
 pub use ix_withdraw_ineligible_reward::*;
+pub mod ix_withdraw_dead_liquidity_reward;
+pub use ix_withdraw_dead_liquidity_reward::*;
 pub mod ix_close_position;
 pub use ix_close_position::*;
 pub mod ix_split_position;

--- a/programs/cp-amm/src/lib.rs
+++ b/programs/cp-amm/src/lib.rs
@@ -153,6 +153,13 @@ pub mod cp_amm {
         instructions::handle_withdraw_ineligible_reward(ctx, reward_index)
     }
 
+    pub fn withdraw_dead_liquidity_reward(
+        ctx: Context<WithdrawDeadLiquidityRewardCtx>,
+        reward_index: u8,
+    ) -> Result<()> {
+        instructions::handle_withdraw_dead_liquidity_reward(ctx, reward_index)
+    }
+
     pub fn update_reward_funder<'info>(
         ctx: Context<'info, UpdateRewardFunderCtx<'info>>,
         reward_index: u8,

--- a/programs/cp-amm/src/state/pool.rs
+++ b/programs/cp-amm/src/state/pool.rs
@@ -344,10 +344,7 @@ impl RewardInfo {
     }
 
     /// get pending dead_liquidity_reward and update the checkpoint
-    pub fn settle_dead_liquidity_reward(
-        &mut self,
-        collect_fee_mode: CollectFeeMode,
-    ) -> Result<u64> {
+    pub fn claim_dead_liquidity_reward(&mut self, collect_fee_mode: CollectFeeMode) -> Result<u64> {
         if collect_fee_mode == CollectFeeMode::Compounding {
             let checkpoint = self.current_dead_liquidity_reward_checkpoint()?;
             let dead_liquidity_reward =
@@ -1121,21 +1118,15 @@ impl Pool {
     }
 
     pub fn claim_ineligible_reward(&mut self, reward_index: usize) -> Result<u64> {
-        let collect_fee_mode: CollectFeeMode = self.collect_fee_mode.safe_cast()?;
-
         // calculate ineligible reward
         let reward_info = &mut self.reward_infos[reward_index];
-        let empty_liquidity_reward: u64 = safe_mul_shr_cast(
+        let ineligible_reward: u64 = safe_mul_shr_cast(
             reward_info
                 .cumulative_seconds_with_empty_liquidity_reward
                 .into(),
             reward_info.reward_rate,
             REWARD_RATE_SCALE,
         )?;
-
-        let dead_liquidity_reward = reward_info.settle_dead_liquidity_reward(collect_fee_mode)?;
-
-        let ineligible_reward = empty_liquidity_reward.safe_add(dead_liquidity_reward)?;
 
         reward_info.cumulative_seconds_with_empty_liquidity_reward = 0;
 

--- a/programs/cp-amm/src/state/pool.rs
+++ b/programs/cp-amm/src/state/pool.rs
@@ -315,38 +315,19 @@ impl RewardInfo {
         self.last_update_time = min(current_time, self.reward_duration_end);
     }
 
-    /// monotonic cumulative dead-liquidity reward, wrapped to u64 (mod 2^64).
-    /// The delta is recovered via `wrapping_sub`, valid while it stays below 2^64.
-    fn current_dead_liquidity_reward_checkpoint(&self) -> Result<u64> {
-        let cumulative = mul_shr_256(
-            U256::from(DEAD_LIQUIDITY),
-            self.reward_per_token_stored(),
-            TOTAL_REWARD_SCALE,
-        )
-        .ok_or_else(|| PoolError::MathOverflow)?;
-
-        Ok(cumulative as u64)
-    }
-
-    /// get pending dead_liquidity_reward without mutating the checkpoint
-    pub fn get_pending_dead_liquidity_reward(
-        &self,
-        collect_fee_mode: CollectFeeMode,
-    ) -> Result<u64> {
-        if collect_fee_mode == CollectFeeMode::Compounding {
-            let checkpoint = self.current_dead_liquidity_reward_checkpoint()?;
-            let dead_liquidity_reward =
-                checkpoint.wrapping_sub(self.dead_liquidity_reward_checkpoint);
-            Ok(dead_liquidity_reward)
-        } else {
-            Ok(0)
-        }
-    }
-
-    /// get pending dead_liquidity_reward and update the checkpoint
+    /// get dead_liquidity_reward and update the checkpoint
     pub fn claim_dead_liquidity_reward(&mut self, collect_fee_mode: CollectFeeMode) -> Result<u64> {
         if collect_fee_mode == CollectFeeMode::Compounding {
-            let checkpoint = self.current_dead_liquidity_reward_checkpoint()?;
+            // Cumulative dead-liquidity reward, wrapped to u64 (mod 2^64)
+            // The checkpoint can grow past 2^64 across many funding rounds (so we use wrapping_sub),
+            // but the delta is the pending reward still sitting in the vault
+            // A vault balance is a u64, so the delta never reaches 2^64 and wraps at most once
+            let checkpoint: u64 = mul_shr_256(
+                U256::from(DEAD_LIQUIDITY),
+                self.reward_per_token_stored(),
+                TOTAL_REWARD_SCALE,
+            )
+            .ok_or_else(|| PoolError::MathOverflow)? as u64;
             let dead_liquidity_reward =
                 checkpoint.wrapping_sub(self.dead_liquidity_reward_checkpoint);
             self.dead_liquidity_reward_checkpoint = checkpoint;

--- a/tests/deadLiquidityReward.test.ts
+++ b/tests/deadLiquidityReward.test.ts
@@ -15,6 +15,7 @@ import {
   createOperator,
   createToken,
   DEAD_LIQUIDITY,
+  derivePoolAuthority,
   encodePermissions,
   expectThrowsErrorCode,
   fundReward,
@@ -25,6 +26,8 @@ import {
   InitializePoolParams,
   initializeReward,
   InitializeRewardParams,
+  MAX_SQRT_PRICE,
+  MIN_LP_AMOUNT,
   MIN_SQRT_PRICE,
   mintSplTokenTo,
   OperatorPermission,
@@ -34,13 +37,17 @@ import {
   U128_MAX,
   U64_MAX,
   warpToTimestamp,
-  withdrawIneligibleReward,
+  withdrawDeadLiquidityReward,
 } from "./helpers";
 import { generateKpAndFund } from "./helpers/common";
 import { BaseFeeMode, encodeFeeTimeSchedulerParams } from "./helpers/feeCodec";
 
 const mustWithdrawErrorCode = getCpAmmProgramErrorCode(
-  "MustWithdrawnIneligibleReward"
+  "MustWithdrawDeadLiquidityReward"
+);
+
+const invalidCollectFeeModeErrorCode = getCpAmmProgramErrorCode(
+  "InvalidCollectFeeMode"
 );
 
 const assertCloseToU64Max = (amount: BN) => {
@@ -63,7 +70,6 @@ describe("Dead liquidity reward (Compounding fee mode only)", () => {
   const REWARD_INDEX = 0;
   const REWARD_DURATION = 24 * 60 * 60; // 1 day
   const REWARD_AMOUNT = new BN(REWARD_DURATION * 1_000); // divisible by 4
-  const REWARD_RATE_SCALE = 64;
 
   const baseFeeData = () =>
     encodeFeeTimeSchedulerParams(
@@ -164,7 +170,7 @@ describe("Dead liquidity reward (Compounding fee mode only)", () => {
     return { pool, position, rewardEnd, rewardMid };
   }
 
-  describe("Funder can withdrawIneligibleReward from DEAD_LIQUIDITY share", () => {
+  describe("Funder can withdrawDeadLiquidityReward from DEAD_LIQUIDITY share", () => {
     it("After the last LP exits", async () => {
       const { pool, position, rewardEnd, rewardMid } =
         await setupFundedCompoundingPool();
@@ -192,7 +198,7 @@ describe("Dead liquidity reward (Compounding fee mode only)", () => {
 
       const rewardVault = afterExit.rewardInfos[REWARD_INDEX].vault;
       const funderBefore = new BN(getTokenBalance(svm, funderRewardAta()));
-      await withdrawIneligibleReward(svm, {
+      await withdrawDeadLiquidityReward(svm, {
         index: REWARD_INDEX,
         funder,
         pool,
@@ -203,8 +209,6 @@ describe("Dead liquidity reward (Compounding fee mode only)", () => {
       const vaultResidual = new BN(getTokenBalance(svm, rewardVault));
 
       expect(vaultResidual.eqn(0)).eq(true);
-      // Without the fix withdrawIneligibleReward returns 0 here
-      // the empty-liquidity counter never increments since DEAD_LIQUIDITY keeps pool.liquidity > 0
       expect(recovered.gtn(0)).eq(true);
     });
 
@@ -226,7 +230,7 @@ describe("Dead liquidity reward (Compounding fee mode only)", () => {
       const rewardVault = getPool(svm, pool).rewardInfos[REWARD_INDEX].vault;
 
       const funderBefore = new BN(getTokenBalance(svm, funderRewardAta()));
-      await withdrawIneligibleReward(svm, {
+      await withdrawDeadLiquidityReward(svm, {
         index: REWARD_INDEX,
         funder,
         pool,
@@ -237,49 +241,59 @@ describe("Dead liquidity reward (Compounding fee mode only)", () => {
       const vaultResidual = new BN(getTokenBalance(svm, rewardVault));
 
       expect(vaultResidual.eqn(0)).eq(true);
-      // Without the fix withdrawIneligibleReward returns 0 here
-      // the empty-liquidity counter never increments since DEAD_LIQUIDITY keeps pool.liquidity > 0
       expect(recovered.gtn(0)).eq(true);
     });
   });
 
-  it("Funding with carryForward = true carries forward the dead liquidity reward", async () => {
-    const { pool, position, rewardEnd } = await setupFundedCompoundingPool();
+  it("Dead liquidity reward blocks funding until withdrawn, regardless of carryForward", async () => {
+    for (const carryForward of [false, true]) {
+      const { pool, rewardMid } = await setupFundedCompoundingPool();
+      const rewardVault = getPool(svm, pool).rewardInfos[REWARD_INDEX].vault;
 
-    warpToTimestamp(svm, rewardEnd);
-    await claimReward(svm, {
-      index: REWARD_INDEX,
-      user: creator,
-      pool,
-      position,
-      skipReward: 0,
-    });
+      warpToTimestamp(svm, rewardMid);
+      // dead liquidity reward is pending, so funding is blocked for both carryForward values
+      const tx = await createCpAmmProgram()
+        .methods.fundReward(REWARD_INDEX, REWARD_AMOUNT, carryForward)
+        .accountsPartial({
+          pool,
+          rewardVault,
+          rewardMint,
+          funderTokenAccount: funderRewardAta(),
+          funder: funder.publicKey,
+          tokenProgram: TOKEN_PROGRAM_ID,
+        })
+        .transaction();
 
-    const rewardInfo = getPool(svm, pool).rewardInfos[REWARD_INDEX];
-    const deadInVault = new BN(getTokenBalance(svm, rewardInfo.vault));
-    expect(deadInVault.gtn(0)).eq(true);
-    // pool was never empty. this also ensures the carry forward only comes from dead liquidity reward
-    expect(rewardInfo.cumulativeSecondsWithEmptyLiquidityReward.eqn(0)).eq(
-      true
-    );
+      expectThrowsErrorCode(
+        sendTransaction(svm, tx, [funder]),
+        mustWithdrawErrorCode
+      );
 
-    // second reward campaign
-    await fundReward(svm, {
-      index: REWARD_INDEX,
-      funder,
-      pool,
-      carryForward: true,
-      amount: REWARD_AMOUNT,
-    });
+      // withdrawing mid-campaign returns the dead liquidity reward to the funder (it is not carried forward into the next campaign)
+      const funderBefore = new BN(getTokenBalance(svm, funderRewardAta()));
+      await withdrawDeadLiquidityReward(svm, {
+        index: REWARD_INDEX,
+        funder,
+        pool,
+      });
+      const funderAfter = new BN(getTokenBalance(svm, funderRewardAta()));
+      expect(funderAfter.gt(funderBefore)).eq(true);
 
-    const vaultAfter = new BN(getTokenBalance(svm, rewardInfo.vault));
-    const rateWithoutCarryOver =
-      REWARD_AMOUNT.shln(REWARD_RATE_SCALE).divn(REWARD_DURATION);
-    const actualRate = getPool(svm, pool).rewardInfos[REWARD_INDEX].rewardRate;
+      const rewardEndBefore = getPool(svm, pool).rewardInfos[REWARD_INDEX]
+        .rewardDurationEnd;
 
-    expect(vaultAfter.gt(REWARD_AMOUNT)).eq(true);
-    expect(vaultAfter.eq(REWARD_AMOUNT.add(deadInVault))).eq(true);
-    expect(actualRate.gt(rateWithoutCarryOver)).eq(true);
+      await fundReward(svm, {
+        index: REWARD_INDEX,
+        funder,
+        pool,
+        carryForward,
+        amount: REWARD_AMOUNT,
+      });
+
+      const rewardEndAfter = getPool(svm, pool).rewardInfos[REWARD_INDEX]
+        .rewardDurationEnd;
+      expect(rewardEndAfter.gt(rewardEndBefore)).eq(true);
+    }
   });
 
   it("dead_liquidity_reward_checkpoint wraps correctly", async () => {
@@ -357,7 +371,11 @@ describe("Dead liquidity reward (Compounding fee mode only)", () => {
     );
 
     const funderBefore1 = new BN(getTokenBalance(svm, funderRewardAta()));
-    await withdrawIneligibleReward(svm, { index: REWARD_INDEX, funder, pool });
+    await withdrawDeadLiquidityReward(svm, {
+      index: REWARD_INDEX,
+      funder,
+      pool,
+    });
     const recovered1 = new BN(getTokenBalance(svm, funderRewardAta())).sub(
       funderBefore1
     );
@@ -379,12 +397,76 @@ describe("Dead liquidity reward (Compounding fee mode only)", () => {
     warpToTimestamp(svm, rewardEnd2.addn(1));
 
     const funderBefore2 = new BN(getTokenBalance(svm, funderRewardAta()));
-    await withdrawIneligibleReward(svm, { index: REWARD_INDEX, funder, pool });
+    await withdrawDeadLiquidityReward(svm, {
+      index: REWARD_INDEX,
+      funder,
+      pool,
+    });
     const recovered2 = new BN(getTokenBalance(svm, funderRewardAta())).sub(
       funderBefore2
     );
 
     // checkpoint has wrapped past u64::MAX; without wrapping this returns 0 or errors
     assertCloseToU64Max(recovered2);
+  });
+
+  it("withdrawDeadLiquidityReward fails on a non-compounding pool", async () => {
+    const nonCompoundingConfig = await createConfigIx(
+      svm,
+      whitelistedAccount,
+      new BN(Math.floor(Math.random() * 1_000_000)),
+      {
+        poolFees: {
+          baseFee: { data: Array.from(baseFeeData()) },
+          compoundingFeeBps: 0,
+          padding: 0,
+          dynamicFee: null,
+        },
+        sqrtMinPrice: MIN_SQRT_PRICE,
+        sqrtMaxPrice: MAX_SQRT_PRICE,
+        vaultConfigKey: PublicKey.default,
+        poolCreatorAuthority: PublicKey.default,
+        activationType: 0,
+        collectFeeMode: 0,
+      }
+    );
+
+    const { pool } = await initializePool(svm, {
+      payer: creator,
+      creator: creator.publicKey,
+      config: nonCompoundingConfig,
+      tokenAMint,
+      tokenBMint,
+      liquidity: MIN_LP_AMOUNT,
+      sqrtPrice: MIN_SQRT_PRICE,
+      activationPoint: null,
+    });
+
+    await initializeReward(svm, {
+      index: REWARD_INDEX,
+      payer: creator,
+      rewardDuration: new BN(REWARD_DURATION),
+      pool,
+      rewardMint,
+      funder: funder.publicKey,
+    });
+
+    const tx = await createCpAmmProgram()
+      .methods.withdrawDeadLiquidityReward(REWARD_INDEX)
+      .accountsPartial({
+        pool,
+        rewardVault: getPool(svm, pool).rewardInfos[REWARD_INDEX].vault,
+        rewardMint,
+        poolAuthority: derivePoolAuthority(),
+        funderTokenAccount: funderRewardAta(),
+        funder: funder.publicKey,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      })
+      .transaction();
+
+    expectThrowsErrorCode(
+      sendTransaction(svm, tx, [funder]),
+      invalidCollectFeeModeErrorCode
+    );
   });
 });

--- a/tests/deadLiquidityReward.test.ts
+++ b/tests/deadLiquidityReward.test.ts
@@ -241,6 +241,48 @@ describe("Dead liquidity reward (Compounding fee mode only)", () => {
     });
   });
 
+  it("Funder can re-fund mid-campaign with pending dead-liquidity reward", async () => {
+    const { pool, rewardMid, rewardEnd } = await setupFundedCompoundingPool();
+
+    warpToTimestamp(svm, rewardMid);
+
+    // fund again without withdrawing first
+    const rewardEndBefore = getPool(svm, pool).rewardInfos[REWARD_INDEX]
+      .rewardDurationEnd;
+    expect(rewardEndBefore.eq(rewardEnd)).eq(true);
+
+    await fundReward(svm, {
+      index: REWARD_INDEX,
+      funder,
+      pool,
+      carryForward: false,
+      amount: REWARD_AMOUNT,
+    });
+
+    const rewardEndAfter = getPool(svm, pool).rewardInfos[REWARD_INDEX]
+      .rewardDurationEnd;
+    expect(rewardEndAfter.gt(rewardEndBefore)).eq(true);
+  });
+
+  it("Funder can withdraw dead-liquidity reward mid-campaign", async () => {
+    const { pool, rewardMid } = await setupFundedCompoundingPool();
+
+    warpToTimestamp(svm, rewardMid);
+
+    const funderBefore = new BN(getTokenBalance(svm, funderRewardAta()));
+    await withdrawDeadLiquidityReward(svm, {
+      index: REWARD_INDEX,
+      funder,
+      pool,
+    });
+    const funderAfter = new BN(getTokenBalance(svm, funderRewardAta()));
+
+    expect(funderAfter.gt(funderBefore)).eq(true);
+    const checkpointAfterWithdraw = getPool(svm, pool).rewardInfos[REWARD_INDEX]
+      .deadLiquidityRewardCheckpoint;
+    expect(checkpointAfterWithdraw.gtn(0)).eq(true);
+  });
+
   it("dead_liquidity_reward_checkpoint wraps correctly", async () => {
     // 2 reward campaigns that each emit ~u64::MAX of reward as dead_liquidity_reward,
     // so the cumulative checkpoint exceeds u64::MAX and must wrap.

--- a/tests/deadLiquidityReward.test.ts
+++ b/tests/deadLiquidityReward.test.ts
@@ -245,8 +245,8 @@ describe("Dead liquidity reward (Compounding fee mode only)", () => {
     });
   });
 
-  it("Dead liquidity reward blocks funding until withdrawn, regardless of carryForward", async () => {
-    for (const carryForward of [false, true]) {
+  for (const carryForward of [false, true]) {
+    it(`Dead liquidity reward blocks funding until withdrawn (carryForward = ${carryForward})`, async () => {
       const { pool, rewardMid } = await setupFundedCompoundingPool();
       const rewardVault = getPool(svm, pool).rewardInfos[REWARD_INDEX].vault;
 
@@ -293,8 +293,8 @@ describe("Dead liquidity reward (Compounding fee mode only)", () => {
       const rewardEndAfter = getPool(svm, pool).rewardInfos[REWARD_INDEX]
         .rewardDurationEnd;
       expect(rewardEndAfter.gt(rewardEndBefore)).eq(true);
-    }
-  });
+    });
+  }
 
   it("dead_liquidity_reward_checkpoint wraps correctly", async () => {
     // 2 reward campaigns that each emit u64::MAX of reward as dead_liquidity_reward,

--- a/tests/deadLiquidityReward.test.ts
+++ b/tests/deadLiquidityReward.test.ts
@@ -42,10 +42,6 @@ import {
 import { generateKpAndFund } from "./helpers/common";
 import { BaseFeeMode, encodeFeeTimeSchedulerParams } from "./helpers/feeCodec";
 
-const mustWithdrawErrorCode = getCpAmmProgramErrorCode(
-  "MustWithdrawDeadLiquidityReward"
-);
-
 const invalidCollectFeeModeErrorCode = getCpAmmProgramErrorCode(
   "InvalidCollectFeeMode"
 );
@@ -245,60 +241,9 @@ describe("Dead liquidity reward (Compounding fee mode only)", () => {
     });
   });
 
-  for (const carryForward of [false, true]) {
-    it(`Dead liquidity reward blocks funding until withdrawn (carryForward = ${carryForward})`, async () => {
-      const { pool, rewardMid } = await setupFundedCompoundingPool();
-      const rewardVault = getPool(svm, pool).rewardInfos[REWARD_INDEX].vault;
-
-      warpToTimestamp(svm, rewardMid);
-      // dead liquidity reward is pending, so funding is blocked for both carryForward values
-      const tx = await createCpAmmProgram()
-        .methods.fundReward(REWARD_INDEX, REWARD_AMOUNT, carryForward)
-        .accountsPartial({
-          pool,
-          rewardVault,
-          rewardMint,
-          funderTokenAccount: funderRewardAta(),
-          funder: funder.publicKey,
-          tokenProgram: TOKEN_PROGRAM_ID,
-        })
-        .transaction();
-
-      expectThrowsErrorCode(
-        sendTransaction(svm, tx, [funder]),
-        mustWithdrawErrorCode
-      );
-
-      // withdrawing mid-campaign returns the dead liquidity reward to the funder (it is not carried forward into the next campaign)
-      const funderBefore = new BN(getTokenBalance(svm, funderRewardAta()));
-      await withdrawDeadLiquidityReward(svm, {
-        index: REWARD_INDEX,
-        funder,
-        pool,
-      });
-      const funderAfter = new BN(getTokenBalance(svm, funderRewardAta()));
-      expect(funderAfter.gt(funderBefore)).eq(true);
-
-      const rewardEndBefore = getPool(svm, pool).rewardInfos[REWARD_INDEX]
-        .rewardDurationEnd;
-
-      await fundReward(svm, {
-        index: REWARD_INDEX,
-        funder,
-        pool,
-        carryForward,
-        amount: REWARD_AMOUNT,
-      });
-
-      const rewardEndAfter = getPool(svm, pool).rewardInfos[REWARD_INDEX]
-        .rewardDurationEnd;
-      expect(rewardEndAfter.gt(rewardEndBefore)).eq(true);
-    });
-  }
-
   it("dead_liquidity_reward_checkpoint wraps correctly", async () => {
-    // 2 reward campaigns that each emit u64::MAX of reward as dead_liquidity_reward,
-    // so the cumulative checkpoint exceeds u64::MAX and must wrap
+    // 2 reward campaigns that each emit ~u64::MAX of reward as dead_liquidity_reward,
+    // so the cumulative checkpoint exceeds u64::MAX and must wrap.
     // if the wrapping happens correctly, the funder should recover ~u64::MAX in round 2
 
     // top the funder up to exactly u64::MAX reward tokens
@@ -330,8 +275,6 @@ describe("Dead liquidity reward (Compounding fee mode only)", () => {
       funder: funder.publicKey,
     });
 
-    const rewardVault = getPool(svm, pool).rewardInfos[REWARD_INDEX].vault;
-
     // LP exits immediately so DEAD_LIQUIDITY is the only share for the whole campaign
     await fundReward(svm, {
       index: REWARD_INDEX,
@@ -353,23 +296,6 @@ describe("Dead liquidity reward (Compounding fee mode only)", () => {
       .rewardDurationEnd;
     warpToTimestamp(svm, rewardEnd1.addn(1));
 
-    // funding again before withdrawing the pending dead_liquidity_reward fails
-    const failedFundTx = await createCpAmmProgram()
-      .methods.fundReward(REWARD_INDEX, U64_MAX, false)
-      .accountsPartial({
-        pool,
-        rewardVault,
-        rewardMint,
-        funderTokenAccount: funderRewardAta(),
-        funder: funder.publicKey,
-        tokenProgram: TOKEN_PROGRAM_ID,
-      })
-      .transaction();
-    expectThrowsErrorCode(
-      sendTransaction(svm, failedFundTx, [funder]),
-      mustWithdrawErrorCode
-    );
-
     const funderBefore1 = new BN(getTokenBalance(svm, funderRewardAta()));
     await withdrawDeadLiquidityReward(svm, {
       index: REWARD_INDEX,
@@ -383,7 +309,7 @@ describe("Dead liquidity reward (Compounding fee mode only)", () => {
     assertCloseToU64Max(recovered1);
 
     // total supply is capped at u64::MAX, so fund the recovered balance (~u64::MAX);
-    // this still pushes the cumulative checkpoint past u64::MAX and forces a wrap
+    // this pushes the cumulative checkpoint past u64::MAX and forces a wrap
     await fundReward(svm, {
       index: REWARD_INDEX,
       funder,

--- a/tests/helpers/cpAmm.ts
+++ b/tests/helpers/cpAmm.ts
@@ -1433,6 +1433,46 @@ export async function withdrawIneligibleReward(
   expect(result).instanceOf(TransactionMetadata);
 }
 
+export type WithdrawDeadLiquidityRewardParams = {
+  index: number;
+  funder: Keypair;
+  pool: PublicKey;
+};
+
+export async function withdrawDeadLiquidityReward(
+  svm: LiteSVM,
+  params: WithdrawDeadLiquidityRewardParams
+): Promise<void> {
+  const { index, pool, funder } = params;
+  const program = createCpAmmProgram();
+
+  const poolState = getPool(svm, pool);
+  const poolAuthority = derivePoolAuthority();
+  const tokenProgram = svm.getAccount(poolState.rewardInfos[index].mint)!.owner;
+  const funderTokenAccount = getAssociatedTokenAddressSync(
+    poolState.rewardInfos[index].mint,
+    funder.publicKey,
+    true,
+    tokenProgram
+  );
+
+  const transaction = await program.methods
+    .withdrawDeadLiquidityReward(index)
+    .accountsPartial({
+      pool,
+      rewardVault: poolState.rewardInfos[index].vault,
+      rewardMint: poolState.rewardInfos[index].mint,
+      poolAuthority,
+      funderTokenAccount,
+      funder: funder.publicKey,
+      tokenProgram,
+    })
+    .transaction();
+
+  const result = sendTransaction(svm, transaction, [funder]);
+  expect(result).instanceOf(TransactionMetadata);
+}
+
 export async function refreshVestings(
   svm: LiteSVM,
   position: PublicKey,


### PR DESCRIPTION
- User can `fund_reward` on compounding pool mid campaign again
- `fund_reward` will not carry forward `dead_liquidity_reward`